### PR TITLE
fix strings

### DIFF
--- a/lib/args.ts
+++ b/lib/args.ts
@@ -18,7 +18,6 @@ export function parse(args: string[], ...extractors: Extractor[]): string[] & { 
 			args = extractor(params, args);
 			if (arg0 !== args[0]) break;
 		}
-		if (args0 === args[0]) break;
 	}
 	if (args[0] === '--') {
 		args.shift();

--- a/lib/test/string.ts
+++ b/lib/test/string.ts
@@ -1,0 +1,30 @@
+import { describe, it } from '@xutl/test';
+import { strict as assert } from 'assert';
+
+import { parse, string } from '../args';
+
+const args = [process.argv0, process.argv[1] as string];
+describe('args', () => {
+	describe('string', () => {
+		it('single', () => {
+			const parsed = parse([...args, '--str', 'hello'], string('str'));
+			assert.deepStrictEqual(parsed.params, {
+				str: 'hello',
+			});
+		});
+		it('multi', () => {
+			//only the last one is taken
+			const parsed = parse([...args, '--str', 'hello', '--str', 'world'], string('str'));
+			assert.deepStrictEqual(parsed.params, {
+				str: 'world',
+			});
+		});
+		it('multi-seperated', () => {
+			const parsed = parse([...args, '--s1', 'hello', '--s2', 'abc', '--s1', 'world'], string('s1'), string('s2'));
+			assert.deepStrictEqual(parsed.params, {
+				s1: 'world',
+				s2: 'abc',
+			});
+		});
+	});
+});

--- a/lib/test/strings.ts
+++ b/lib/test/strings.ts
@@ -1,0 +1,43 @@
+import { describe, it } from '@xutl/test';
+import { strict as assert } from 'assert';
+
+import { parse, strings, string } from '../args';
+
+const args = [process.argv0, process.argv[1] as string];
+describe('args', () => {
+	describe('strings', () => {
+		it('single', () => {
+			const parsed = parse([...args, '--strs', 'hello'], strings('strs'));
+			assert.deepStrictEqual(parsed.params, {
+				strs: ['hello'],
+			});
+		});
+		it('multi', () => {
+			const parsed = parse([...args, '--strs', 'hello', '--strs', 'world'], strings('strs'));
+			assert.deepStrictEqual(parsed.params, {
+				strs: ['hello', 'world'],
+			});
+		});
+		it('seperate', () => {
+			const parsed = parse([...args, '--strs', 'hello', '--single', 'abc', '--strs', 'world'], string('single'), strings('strs'));
+			assert.deepStrictEqual(parsed.params, {
+				single: 'abc',
+				strs: ['hello', 'world'],
+			});
+		});
+		it('mix', () => {
+			const parsed = parse([...args, '--s1', 'hello', '--s1', 'world', '--s2', 'abc', '--s2', '123'], strings('s1'), strings('s2'));
+			assert.deepStrictEqual(parsed.params, {
+				s1: ['hello', 'world'],
+				s2: ['abc', '123'],
+			});
+		});
+		it('mix2', () => {
+			const parsed = parse([...args, '--s1', 'hello', '--s2', 'abc', '--s1', 'world', '--s2', '123'], strings('s1'), strings('s2'));
+			assert.deepStrictEqual(parsed.params, {
+				s1: ['hello', 'world'],
+				s2: ['abc', '123'],
+			});
+		});
+	});
+});


### PR DESCRIPTION
## summary
`strings()` extractor does not working due to this [line](https://github.com/xutl-es/args/compare/main...davidwonghk:hotfix/strings?expand=1#diff-e447332b108dfb6505f7566e307469745e4cc5c5a451468d696e4ba8c5fa6226L21) early breaking, results in only accept a single string instead of multiple strings (as string array).

Note that the change in implementation I suggest here amends the behavior of other non-array extractor.
- before: if multiple argument with same name supply(eg. `--abc=123 --abc=456`), the first one would be extracted (=123)
- after: the last one would be extracted (=456)

Please check the added test cases to ensure this is the desire behavior. 