### PR TITLE
use target es2019 for better node compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
 		/* Basic Options */
 		// "incremental": true,                   /* Enable incremental compilation */
-		"target": "ESNEXT" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+		"target": "ES2019" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
 		"module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
 		// "lib": [],                             /* Specify library files to be included in the compilation. */
 		// "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
since optional chaining is not supported before node 14, 
use target=es2019 in tsconfig for better compatibility for previous versions of nodejs.